### PR TITLE
[GITOPS] - Merging 'user-branch-10167501342' in 'release' - Initiate Release Process

### DIFF
--- a/.github/workflows/go-pr-to-main.yml
+++ b/.github/workflows/go-pr-to-main.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.event.pull_request.merged == true && (
       startsWith(github.event.pull_request.title, '[GITOPS]')
       )
-    uses: boromir674/automated-workflows/.github/workflows/go-pr-to-main.yml@dev-branch
+    uses: boromir674/automated-workflows/.github/workflows/go-pr-to-main.yml@test
     with:
       main_branch: ${{ vars.GIT_MAIN_BRANCH || 'main' }}
       release_branch: ${{ vars.GITOPS_RELEASE_BRANCH || 'release' }}

--- a/.github/workflows/go-pr-to-release.yml
+++ b/.github/workflows/go-pr-to-release.yml
@@ -14,7 +14,7 @@ on:
       - release-me  # Request to be included in next Release and create a Release
 jobs:
   pr_to_release:
-    uses: boromir674/automated-workflows/.github/workflows/go-pr-to-release.yml@dev-branch
+    uses: boromir674/automated-workflows/.github/workflows/go-pr-to-release.yml@test
     with:
       # pass tag to PR from <user_branch>  -->  <github.ref>-<user_branch>
       release_branch: ${{ vars.GITOPS_RELEASE_BRANCH || 'release' }}

--- a/user-branch-10167501342.txt
+++ b/user-branch-10167501342.txt
@@ -1,0 +1,1 @@
+User Branch


### PR DESCRIPTION
## :rocket: Initiating Release Process :rocket:

  This PR marks a pivotal moment in our deployment cycle, signaling that all changes on the **Release Train (RT)** are deemed ready for release. It represents the collective decision of our developers that the changes bundled in the RT are suitable to be released together.

  ### What's Happening in This PR?

  - We are merging the  branch into the  branch.
  - This action is a critical step, transitioning us from the development phase to the release phase.

  ### :white_check_mark: Automatic Merging Upon CI Checks :white_check_mark:

  - This PR is configured to **automatically merge** once all CI checks successfully pass.
  - These checks include running our comprehensive test suite on the RT branch to ensure a minimum standard of quality, covering sanity checks, QA, and unit tests.

  ### Ensuring Quality and Preparing for Release:

  - Our focus now shifts to **stress testing** and on CI.
  - We'll also handle essential chores, like updating the changelog with a new entry dedicated for the imminent release.

  ### :bulb: Next Steps in Our Journey:

  - Following the successful merge of this PR, we'll initiate the next phase, which involves merging the  into the **** branch.

  ### :hourglass_flowing_sand: Looking Ahead:

  - Once merged, our changes are set for the final stage of release preparation.
  